### PR TITLE
Update new_folder_with_selection.nemo_action

### DIFF
--- a/new_folder_with_selection.nemo_action
+++ b/new_folder_with_selection.nemo_action
@@ -2,10 +2,10 @@
 
 Active=true
 
-Name[en]=Create new folder with selection
-Name [pt]=Criar nova pasta com seleção
+Name=Create new folder with selection
+Name[pt]=Criar nova pasta com seleção
 
-Comment[en]=Creates a new folder with the selected items
+Comment=Creates a new folder with the selected items
 Comment[pt]=Cria uma nova pasta com os itens selecionados
 Exec=<new_folder_with_selection.sh %P %F>
 


### PR DESCRIPTION
remove [en] from Name label as otherwise Nemo 4.6.4 throws "An action definition requires, at minimum, a Label field, an Exec field, a Selection field, and an either an Extensions or Mimetypes field." due to missing Name label and won't load the action.